### PR TITLE
ci: use out cluster to build images faster

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -17,6 +17,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: us-east-2
+          role-to-assume: arn:aws:iam::312272277431:role/github-actions/buildx-deployments
+          role-session-name: PluralCLI
+      - name: setup kubectl
+        uses: azure/setup-kubectl@v3
+      - name: Get EKS credentials
+        run: aws eks update-kubeconfig --name pluraldev
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
@@ -29,10 +39,33 @@ jobs:
             type=sha
             type=ref,event=pr
             type=ref,event=branch
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
+        id: builder
         uses: docker/setup-buildx-action@v2
+        with:
+          driver: kubernetes
+          platforms: linux/amd64
+          driver-opts: |
+            namespace=buildx
+            requests.cpu=1.5
+            requests.memory=3.5Gi
+            "nodeselector=plural.sh/scalingGroup=buildx-spot-x86"
+            "tolerations=key=plural.sh/capacityType,value=SPOT,effect=NoSchedule;key=plural.sh/reserved,value=BUILDX,effect=NoSchedule"
+      - name: Append ARM buildx builder from AWS
+        run: |
+          docker buildx create \
+            --append \
+            --bootstrap \
+            --name ${{ steps.builder.outputs.name }} \
+            --driver=kubernetes \
+            --platform linux/arm64 \
+            --node=${{ steps.builder.outputs.name }}-arm64 \
+            --buildkitd-flags "--allow-insecure-entitlement security.insecure --allow-insecure-entitlement network.host" \
+            --driver-opt namespace=buildx \
+            --driver-opt requests.cpu=1.5 \
+            --driver-opt requests.memory=3.5Gi \
+            '--driver-opt="nodeselector=plural.sh/scalingGroup=buildx-spot-arm64"' \
+            '--driver-opt="tolerations=key=plural.sh/capacityType,value=SPOT,effect=NoSchedule;key=plural.sh/reserved,value=BUILDX,effect=NoSchedule"'
       - name: Login to GHCR
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: us-east-2
+          role-to-assume: arn:aws:iam::312272277431:role/github-actions/buildx-deployments
+          role-session-name: PluralCLI
+      - name: setup kubectl
+        uses: azure/setup-kubectl@v3
+      - name: Get EKS credentials
+        run: aws eks update-kubeconfig --name pluraldev
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
@@ -24,10 +34,33 @@ jobs:
           # generate Docker tags based on the following events/attributes
           tags: |
             type=semver,pattern={{version}}
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
+        id: builder
         uses: docker/setup-buildx-action@v2
+        with:
+          driver: kubernetes
+          platforms: linux/amd64
+          driver-opts: |
+            namespace=buildx
+            requests.cpu=1.5
+            requests.memory=3.5Gi
+            "nodeselector=plural.sh/scalingGroup=buildx-spot-x86"
+            "tolerations=key=plural.sh/capacityType,value=SPOT,effect=NoSchedule;key=plural.sh/reserved,value=BUILDX,effect=NoSchedule"
+      - name: Append ARM buildx builder from AWS
+        run: |
+          docker buildx create \
+            --append \
+            --bootstrap \
+            --name ${{ steps.builder.outputs.name }} \
+            --driver=kubernetes \
+            --platform linux/arm64 \
+            --node=${{ steps.builder.outputs.name }}-arm64 \
+            --buildkitd-flags "--allow-insecure-entitlement security.insecure --allow-insecure-entitlement network.host" \
+            --driver-opt namespace=buildx \
+            --driver-opt requests.cpu=1.5 \
+            --driver-opt requests.memory=3.5Gi \
+            '--driver-opt="nodeselector=plural.sh/scalingGroup=buildx-spot-arm64"' \
+            '--driver-opt="tolerations=key=plural.sh/capacityType,value=SPOT,effect=NoSchedule;key=plural.sh/reserved,value=BUILDX,effect=NoSchedule"'
       - name: Login to GHCR
         uses: docker/login-action@v2
         with:


### PR DESCRIPTION
This will allow us to build the container images on our cluster to speed up builds a lot.